### PR TITLE
Add await keyword to assemblyApi function calls

### DIFF
--- a/src/app/api/request/route.ts
+++ b/src/app/api/request/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: Request) {
     limit?: number;
   };
 
-  const assembly = assemblyApi({
+  const assembly = await assemblyApi({
     apiKey,
     token,
   });

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -14,7 +14,7 @@ export async function getSession(searchParams: SearchParams) {
     'ASSEMBLY_API_KEY is required, guide available at: https://docs.assembly.com/docs/custom-apps-setting-up-your-first-app#step-2-register-your-app-and-get-an-api-key',
   );
 
-  const assembly = assemblyApi({
+  const assembly = await assemblyApi({
     apiKey: apiKey,
     token:
       'token' in searchParams && typeof searchParams.token === 'string'


### PR DESCRIPTION
## Summary
Updated two files to properly await the `assemblyApi` function calls, indicating that this function is asynchronous and returns a Promise. This was needed after publishing the latest version of the assembly-js/node-sdk since v4 makes init async.

## Key Changes
- **src/app/api/request/route.ts**: Added `await` keyword when calling `assemblyApi()`
- **src/utils/session.ts**: Added `await` keyword when calling `assemblyApi()`

## Implementation Details
The `assemblyApi` function appears to be an async function that was previously being called without awaiting its result. This change ensures that the code properly waits for the Promise to resolve before using the returned assembly instance. This fix prevents potential issues with undefined values or race conditions when the assembly object is used in subsequent operations.

https://claude.ai/code/session_01BqDLzCTj5UCykzfsmLXyJe